### PR TITLE
Remove content security

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
     "broccoli-asset-rev": "0.3.0",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
     "ember-cli": "0.0.47",
-    "ember-cli-content-security-policy": "0.1.3",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.0.2",
     "ember-cli-qunit": "0.1.0",
     "ember-cli-sass": "^1.0.2",
     "ember-data": "1.0.0-beta.10",
     "express": "^4.8.5",
-    "glob": "^4.0.5"
+    "glob": "^4.0.5",
+    "broccoli-sass": "~0.2.2"
   }
 }


### PR DESCRIPTION
We don't need this and it stops us from using external resources and inline styles etc.
